### PR TITLE
Fix name of the directory parameter

### DIFF
--- a/doc/create.md
+++ b/doc/create.md
@@ -18,7 +18,7 @@ var gulp = require('gulp'),
 
 gulp.task('create', function() {
     return gulp.src('dist')
-        .pipe(create({directory: 'myproject', id: 'com.myproject.hello', name: 'MyProject'}));
+        .pipe(create({dir: 'myproject', id: 'com.myproject.hello', name: 'MyProject'}));
 });
 ```
 


### PR DESCRIPTION
As per https://github.com/SamVerschueren/gulp-cordova-create this should be `dir`.
